### PR TITLE
INITIAL: Add extras to simplify to explore clang-tidy and clang-tidy wrappers/runners.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,13 @@
+---
+Checks: "*,
+  clang-diagnostic-*,
+  -llvmlibc-*,
+  -misc-*,
+  -altera-*,
+  "
+WarningsAsErrors: "bugprone-*,cert-*"
+# WarningsAsErrors: "bugprone-*,cert-*,clang-analyzer-*"
+HeaderFilterRegex: ""
+FormatStyle:     none
+...
+

--- a/.clang-tidy.json
+++ b/.clang-tidy.json
@@ -1,0 +1,9 @@
+{
+    "paths": [
+      "false-negative/**/*.cpp"
+    ],
+    "buildRoot": "build.debug",
+    "tidyFile": ".clang-tidy",
+    "tidyRoot": ".",
+    "command": "/usr/local/opt/llvm/bin/clang-tidy"
+}

--- a/.codechecker.skip_file
+++ b/.codechecker.skip_file
@@ -1,0 +1,2 @@
+-/Applications/*
++*/*.cpp

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,30 @@
+# ===========================================================================
+# PROJECT ENVIRONMENT SETUP: cxx.explore/.envrc
+# ===========================================================================
+# SHELL: bash (or similiar)
+# SEE ALSO:   https://direnv.net/
+# REPOSITORY: https://github.com/direnv/direnv
+# USAGE:
+#   source .envrc
+#
+#   # -- BETTER: Use direnv (requires: Setup in bash / HOME/.bashrc)
+#   # eval "$(direnv hook bash)"
+#   direnv allow .
+# ===========================================================================
+# direnv_version <version_at_least>
+
+source_env_if_exists .envrc.use_venv
+
+LLVM_HOME="/usr/local/opt/llvm"
+export LLVM_BINDIR="${LLVM_HOME}/bin"
+
+if ! has clang-tidy; then
+    echo "USING: LLVM_HOME=${LLVM_HOME}"
+    path_add PATH "${LLVM_BINDIR}"
+fi
+if has cmake; then
+    echo "FOUND: cmake"
+fi
+if has 'clang-tidy'; then
+    echo "FOUND: clang-tidy"
+fi

--- a/.envrc.use_venv
+++ b/.envrc.use_venv
@@ -1,0 +1,21 @@
+# ===========================================================================
+# PROJECT ENVIRONMENT SETUP: .envrc.use_venv
+# ===========================================================================
+# DESCRIPTION:
+#   Setup and use a Python virtual environment (venv).
+#   On entering the directory: Creates and activates a venv for a python version.
+#   On leaving  the directory: Deactivates the venv (virtual environment).
+#
+# ENABLE/DISABLE THIS OPTIONAL PART:
+#   * TO ENABLE:  Rename ".envrc.use_venv.disabled" to ".envrc.use_venv"
+#   * TO DISABLE: Rename ".envrc.use_venv" to ".envrc.use_venv.disabled"
+#
+# SEE ALSO:
+#   * https://direnv.net/
+#   * https://github.com/direnv/direnv/wiki/Python
+#   * https://direnv.net/man/direnv-stdlib.1.html#codelayout-python-ltpythonexegtcode
+# ===========================================================================
+
+# -- VIRTUAL ENVIRONMENT SUPPORT: layout python python3
+# VENV LOCATION: .direnv/python-$(PYTHON_VERSION)
+layout python python3

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,17 @@
 fnr/
 fpr/
+
+# -- EXTRA-DIRECTORIES:
+__*/
+.cpp-linter_cache/
+.direnv/
+build/
+build.*/
+codechecker.reports/
+codechecker.reports_html/
+
+# -- EXTRA-FILES:
+clang-tidy-checks.py
+*.log
+*.html
+__*.*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,71 @@
+# ===========================================================================
+# CMAKE: clang-tidy-mistakes
+# ===========================================================================
+# DESCRIPTION:
+#   Example repository with C++ mistakes that can be found with clang-tidy.
+#   Allows to explore "clang-tidy" and its features.
+#
+# EXAMPLE:
+#   # -- STEP: Use CMake to build compile-database: $BUILD_DIR/compile_commands.json
+#   BUILD_DIR=build
+#   cmake -S . -B $BUILD_DIR -G Ninja
+#   cmake --build $BUILD_DIR
+#   # -- POSTCONDITION: "$BUILD_DIR/compile_commands.json" exists
+#
+#   # -- STEP: Use "$BUILD_DIR/compile_commands.json" with clang-tidy, ...
+#   clang-tidy -p $BUILD_DIR false-negative/*.cpp
+#   run-clang-tidy -p $BUILD_DIR
+#
+# SEE ALSO:
+#  * https://github.com/polystat/clang-tidy-mistakes
+#  * https://releases.llvm.org/16.0.0/tools/clang/tools/extra/docs/clang-tidy/index.html
+# ===========================================================================
+
+cmake_minimum_required(VERSION 3.20..3.26)
+
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    # -- SCOPE: MASTER_PROJECT
+    message(STATUS "cmake.version: ${CMAKE_VERSION}")
+endif()
+
+# --------------------------------------------------------------------------
+# PROJECT:
+# ---------------------------------------------------------------------------
+project(clang_tidy_mistakes VERSION 0.1 LANGUAGES CXX)
+
+if(NOT DEFINED CMAKE_EXPORT_COMPILE_COMMANDS)
+    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+endif()
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+message(STATUS "USING: CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}")
+
+
+# ---------------------------------------------------------------------------
+# SECTION: LIBS
+# ---------------------------------------------------------------------------
+add_library(cxx_false_negative)
+target_sources(cxx_false_negative PRIVATE
+    "false-negative/buffer-overrun.cpp"
+    "false-negative/const-assignment.cpp"
+    "false-negative/data-execution.cpp"
+    "false-negative/dependency-loop.cpp"
+    "false-negative/destructor-exception.cpp"
+    "false-negative/duplicated-delete.cpp"
+    "false-negative/float-loop.cpp"
+    "false-negative/function-cast.cpp"
+    "false-negative/global-null.cpp"
+    "false-negative/infinite-recursion.cpp"
+    "false-negative/inifite-goto.cpp"
+    "false-negative/long-loop.cpp"
+    "false-negative/memcpy-buffer-overrun.cpp"
+    "false-negative/noexcept-crash.cpp"
+    "false-negative/null-escaping.cpp"
+    "false-negative/stack-corruption.cpp"
+    "false-negative/thread-invalid-stack.cpp"
+    "false-negative/thread-recursion.cpp"
+    "false-negative/unhandled-exception.cpp"
+    "false-negative/virtual-call-constructor.cpp"
+    "false-negative/virtual-div-by-zero.cpp"
+)

--- a/invoke.yaml
+++ b/invoke.yaml
@@ -1,0 +1,32 @@
+# =====================================================
+# INVOKE CONFIGURATION:
+# =====================================================
+# -- ON WINDOWS:
+# run:
+#   echo: true
+#   pty:  false
+#   shell: C:\Windows\System32\cmd.exe
+# MAYBE: tasks: auto_dash_names: false
+# =====================================================
+# SEE: https://pyinvoke.org/
+
+cleanup:
+    extra_directories:
+      - "build"
+      - "build.*"
+      - "codechecker.reports"
+      - "codechecker.reports_html"
+      - ".cpp-linter_cache"
+
+    extra_files:
+      - "clang-tidy-checks.py"
+      - "*.html"
+      - "*.log"
+
+cleanup_all:
+    extra_directories:
+      - .direnv
+      - ".venv*"
+
+#    extra_files:
+#      - "codechecker.json"

--- a/py.requirements.txt
+++ b/py.requirements.txt
@@ -1,0 +1,58 @@
+# =============================================================
+# PYTHON PACKAGE REQUIREMENTS:
+# =============================================================
+# USE: pip install -r <THIS_FILE>
+#
+# RELATED TO: clang-tidy, run-clang-tidy
+# * https://releases.llvm.org/16.0.0/tools/clang/tools/extra/docs/clang-tidy/index.html
+#   https://github.com/llvm/llvm-project
+#   https://github.com/llvm/llvm-project/tree/main/clang-tools-extra
+#   https://www.kdab.com/clang-tidy-part-1-modernize-source-code-using-c11c14/
+#
+# RELATED: EXAMPLE REPO to use clang-tidy
+# * https://github.com/polystat/clang-tidy-mistakes
+#
+# RELATED: clang-tidy runner/wrapper
+# * https://github.com/lmapii/run-clang-tidy
+#   -- OTHER run-clang-tidy (using: Rust), parallel runner that allows to select sources to use
+#   -- USE: cargo install run-clang-tidy
+#
+# * https://github.com/Ericsson/codechecker
+#     CodeChecker check --logfile build.multi/compile_commands.json -o results/
+#     CodeChecker parse -e html ./results -o ./reports_html
+#
+# RELATED: Additional tools for clang-tidy output, ...
+# * https://github.com/austinbhale/clang-tidy-html
+#   -- Provides an HTML report, BAD IF: --list-checks are used (like: run-clang-tidy)
+#
+# RELATED: Install clang-tidy, ... tools by using pip as package manager
+# * https://github.com/cpp-linter/clang-tools-pip
+#   -- Tool to install "clang-tools" that allows you to down the clang-tools in a version.
+#
+# MORE RUNNERS: clang-tidy runner/wrapper
+#  * https://github.com/cpp-linter/cpp-linter
+#  * https://github.com/rasjani/processcdb
+#
+# SCRATCHPAD:
+#   https://github.com/huuanhhuynguyen/cpp_quality_benchmark
+# =============================================================
+
+codechecker
+clang-html
+
+# -- DEVELOP SUPPORT:
+# BAD-LOCAL-FILE: /Users/xxx/.../invoke-cleanup
+invoke >= 1.7.0
+git+https://github.com/jenisys/invoke-cleanup@v0.3.7
+git+https://github.com/jenisys/cmake-build
+
+# -- BUILD-SUPPORT: Normally not needed
+# HINT: Install cmake, ninja via pip package manager.
+#  cmake
+#  ninja
+
+# -- DISABLED:
+#  clang-tools
+#  cpp-linter
+#  processcdb
+

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# =============================================================================
+# INVOKE TASKS
+# =============================================================================
+# SEE: https://pyinvoke.org/
+
+from __future__ import absolute_import, print_function
+from contextlib import contextmanager
+from io import StringIO
+from pathlib import Path
+import sys
+from invoke import task, Collection
+
+# -- MORE TASKS:
+import invoke_cleanup as cleanup
+
+
+# -----------------------------------------------------------------------------
+# CONSTANTS
+# -----------------------------------------------------------------------------
+BUILD_DIR = Path("build.debug")
+COMPILE_COMMANDS_FILE = BUILD_DIR/"compile_commands.json"
+
+
+# -----------------------------------------------------------------------------
+# UTILITY FUNCTIONS
+# -----------------------------------------------------------------------------
+def _require_existing_source_file_or_directory(source_path, file_extension="cpp"):
+    if not source_path:
+        print("REQUIRES source_path (as: file or directory")
+        sys.exit(1)
+
+    source_path = Path(source_path)
+    if source_path.is_dir():
+        source_path = source_path/f"*.{file_extension}"
+    elif not source_path.exists():
+        print("FileNotFoundError: {}".format(source_path))
+        # MAYBE: raise FileNotFoundError(str(source_path))
+        sys.exit(2)
+    return source_path
+
+
+@contextmanager
+def capture_output():
+    """Provide a context-manager to capture-output to a stream."""
+    # -- try .. finally:
+    # ENSURE ON_EXIT: is used if with-block raises an exception.
+    try:
+        # -- ON_ENTER:
+        output_stream = StringIO()
+        yield output_stream
+    finally:
+        # -- ON_EXIT:
+        print("CAPTURED_OUTPUT:")
+        print(output_stream.getvalue())
+        output_stream.close()
+
+
+# -----------------------------------------------------------------------------
+# TASKS
+# -----------------------------------------------------------------------------
+@task
+def build(ctx):
+    """Build the project (and: compile_commands.json)"""
+    ctx.run("cmake-build")
+
+
+@task
+def _ensure_compile_database_exists(ctx):
+    if not COMPILE_COMMANDS_FILE.exists():
+        print("NEEDS: build")
+        build(ctx)
+
+
+@task(pre=[_ensure_compile_database_exists])
+def clang_tidy(ctx, source_path=None):
+    """Run clang-tidy on a source-file or source-directory"""
+    build_dir = BUILD_DIR
+    if source_path:
+        source_path = _require_existing_source_file_or_directory(source_path)
+    else:
+        source_path = "false-negative/*.cpp"
+    ctx.run(f"clang-tidy -p {build_dir} {source_path}",
+            echo=True, pty=True)
+
+
+@task(pre=[_ensure_compile_database_exists])
+def run_clang_tidy(ctx, jobs=1):
+    """Use run-clang-tidy to run clang-tidy on sources"""
+    try:
+        build_dir = BUILD_DIR
+        ctx.run(f"run-clang-tidy -p {build_dir} -j {jobs}",
+                echo=True, pty=True, hide="stderr")
+        print("PASSED")
+    except Exception as e:
+        print("FAILED: %s:%s" % (e.__class__.__name__, e))
+
+
+# -- ALTERNATIVE SOLUTION:
+# @task(pre=[_ensure_compile_database_exists])
+# def __run_clang_tidy_captured(ctx, jobs=1):
+#     """Use run-clang-tidy to run clang-tidy on sources"""
+#     try:
+#         with capture_output() as output:
+#             build_dir = BUILD_DIR
+#             ctx.run(f"run-clang-tidy -p {build_dir} -j {jobs}",
+#                     echo=True, pty=True, out_stream=output, hide="stderr")
+#                     # warning=True)
+#         print("PASSED")
+#     except Exception as e:
+#         print("EXCEPTION: %s:%s" % (e.__class__.__name__, e))
+#         print("FAILED")
+
+
+@task(pre=[_ensure_compile_database_exists])
+def cargo_run_clang_tidy(ctx, jobs=1):
+    """Use run-clang-tidy <https://github.com/lmapii/run-clang-tidy>"""
+    ctx.run(f"$HOME/.cargo/bin/run-clang-tidy .clang-tidy.json -j {jobs}",
+            echo=True, pty=True)
+
+
+@task(pre=[_ensure_compile_database_exists])
+def codechecker(ctx):
+    """Run codechecker"""
+    compile_commands_file = COMPILE_COMMANDS_FILE
+    reports_dir = "codechecker.reports"
+    reports_html_dir = "codechecker.reports_html"
+    skip_file = ".codechecker.skip_file"
+
+    # try:
+    #     ctx.run(f"CodeChecker check --logfile={compile_commands_file} -o {reports_dir}")
+    # except Exception as e:
+    #     print("EXCEPTION: %s:%s" % (e.__class__.__name__, e))
+
+    try:
+        print(f"STEP: codechecker: Analyzing ... to {reports_dir}")
+        ctx.run(f"CodeChecker analyze {compile_commands_file} --output={reports_dir}  --skip={skip_file}",
+                echo=True, pty=True, warn=True)
+    except Exception as e:
+        print("EXCEPTION: %s:%s" % (e.__class__.__name__, e))
+    print("_" * 60)
+    print(f"STEP: codechecker: Generate HTML to: {reports_html_dir}")
+    ctx.run(f"CodeChecker parse -e html {reports_dir} -o {reports_html_dir}",
+            echo=True, pty=True)
+
+
+
+namespace = Collection()
+namespace.add_collection(Collection.from_module(cleanup), name="cleanup")
+namespace.add_task(build)
+namespace.add_task(clang_tidy)
+namespace.add_task(run_clang_tidy)
+namespace.add_task(cargo_run_clang_tidy)
+namespace.add_task(codechecker)


### PR DESCRIPTION
ADDED:
* CMakeLists.txt 
   REASON: Simplifies build a "$BUILD_DIR/compile_commands.json" 
   that is used/usable by clang-tidy and clang-tidy runners

* invoke tasks as simple build-system 
  REASONS:
    - Simplify running clang-tidy tools in a reproducible way
    - Simplify cleanup(s)

* .clang_tidy -- Example clang-tidy config-file
* .clang_tidy.json -- Config-file for Rust based "run-clang-tidy":
* .envrc Simplify setup of environment vars, venv, etc. when project directory is entered.
* py.requirements.txt
  REASON: Simplify installation of clang-tidy tools with "pip".